### PR TITLE
Fix class name and theme selection handling

### DIFF
--- a/MLab_0.1.html
+++ b/MLab_0.1.html
@@ -94,7 +94,7 @@
             margin-bottom: 25px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 18px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -268,7 +268,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -276,19 +276,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="button theme-button" onclick="selectTheme('数与运算')">
+                <button class="button theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="button theme-button" onclick="selectTheme('量与计量')">
+                <button class="button theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="button theme-button" onclick="selectTheme('图形与几何')">
+                <button class="button theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="button theme-button" onclick="selectTheme('概率与统计')">
+                <button class="button theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -336,7 +336,7 @@
             }, 250);
         }
 
-        function selectTheme(theme) {
+        function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';

--- a/MLab_0.2.34.html
+++ b/MLab_0.2.34.html
@@ -94,7 +94,7 @@
             margin-bottom: 25px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 18px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -268,7 +268,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -276,19 +276,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="button theme-button" onclick="selectTheme('数与运算')">
+                <button class="button theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="button theme-button" onclick="selectTheme('量与计量')">
+                <button class="button theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="button theme-button" onclick="selectTheme('图形与几何')">
+                <button class="button theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="button theme-button" onclick="selectTheme('概率与统计')">
+                <button class="button theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -337,7 +337,7 @@
             }, 250);
         }
 
-        function selectTheme(theme) {
+        function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';

--- a/MLab_0.2.41.html
+++ b/MLab_0.2.41.html
@@ -93,7 +93,7 @@
             margin-bottom: 25px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 16px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -222,7 +222,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 id="mlab" class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -230,19 +230,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="theme-button" onclick="selectTheme('数与运算')">
+                <button class="theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="theme-button" onclick="selectTheme('量与计量')">
+                <button class="theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="theme-button" onclick="selectTheme('图形与几何')">
+                <button class="theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="theme-button" onclick="selectTheme('概率与统计')">
+                <button class="theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -280,7 +280,7 @@
             transitionScreens('welcomeScreen', 'themeSelectionScreen');
         }
 
-        function selectTheme(theme) {
+        function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';
@@ -303,6 +303,9 @@
             from.style.pointerEvents = 'none';
 
             // Adjust container size based on the target screen
+            // - welcomeScreen: 40% width, 250px height
+            // - themeSelectionScreen: 80% width, 400px height
+            // - experimentScreen: 90% width, 80vh height
             if (toScreen === 'welcomeScreen') {
                 container.style.width = '40%';
                 container.style.height = '250px';

--- a/MLab_0.2.43.html
+++ b/MLab_0.2.43.html
@@ -93,7 +93,7 @@
             margin-bottom: 20px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 16px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -223,7 +223,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 id="mlab" class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -231,19 +231,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="theme-button" onclick="selectTheme('数与运算')">
+                <button class="theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="theme-button" onclick="selectTheme('量与计量')">
+                <button class="theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="theme-button" onclick="selectTheme('图形与几何')">
+                <button class="theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="theme-button" onclick="selectTheme('概率与统计')">
+                <button class="theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -281,7 +281,7 @@
             transitionScreens('welcomeScreen', 'themeSelectionScreen');
         }
 
-        function selectTheme(theme) {
+        function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';
@@ -304,6 +304,9 @@
             from.style.pointerEvents = 'none';
 
             // Adjust container size based on the target screen
+            // - welcomeScreen: 40% width, 250px height
+            // - themeSelectionScreen: 60% width, 350px height
+            // - experimentScreen: 90% width, 80vh height
             if (toScreen === 'welcomeScreen') {
                 container.style.width = '40%';
                 container.style.height = '250px';

--- a/MLab_0.3.11.html
+++ b/MLab_0.3.11.html
@@ -93,7 +93,7 @@
             margin-bottom: 20px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 16px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -300,7 +300,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 id="mlab" class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -308,19 +308,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="theme-button" onclick="selectTheme('数与运算')">
+                <button class="theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="theme-button" onclick="selectTheme('量与计量')">
+                <button class="theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="theme-button" onclick="selectTheme('图形与几何')">
+                <button class="theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="theme-button" onclick="selectTheme('概率与统计')">
+                <button class="theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -387,7 +387,7 @@
             transitionScreens('welcomeScreen', 'themeSelectionScreen');
         }
 
-        function selectTheme(theme) {
+        function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';
@@ -410,6 +410,9 @@
             from.style.pointerEvents = 'none';
 
             // Adjust container size based on the target screen
+            // - welcomeScreen: 40% width, 250px height
+            // - themeSelectionScreen: 60% width, 350px height
+            // - experimentScreen: 90% width, 80vh height
             if (toScreen === 'welcomeScreen') {
                 container.style.width = '40%';
                 container.style.height = '250px';

--- a/MLab_0.3.3.html
+++ b/MLab_0.3.3.html
@@ -93,7 +93,7 @@
             margin-bottom: 20px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 16px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -263,7 +263,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 id="mlab" class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -271,19 +271,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="theme-button" onclick="selectTheme('数与运算')">
+                <button class="theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="theme-button" onclick="selectTheme('量与计量')">
+                <button class="theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="theme-button" onclick="selectTheme('图形与几何')">
+                <button class="theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="theme-button" onclick="selectTheme('概率与统计')">
+                <button class="theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -328,7 +328,7 @@
             transitionScreens('welcomeScreen', 'themeSelectionScreen');
         }
 
-        function selectTheme(theme) {
+        function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';
@@ -351,6 +351,9 @@
             from.style.pointerEvents = 'none';
 
             // Adjust container size based on the target screen
+            // - welcomeScreen: 40% width, 250px height
+            // - themeSelectionScreen: 60% width, 350px height
+            // - experimentScreen: 90% width, 80vh height
             if (toScreen === 'welcomeScreen') {
                 container.style.width = '40%';
                 container.style.height = '250px';

--- a/MLab_0.3.7.html
+++ b/MLab_0.3.7.html
@@ -93,7 +93,7 @@
             margin-bottom: 20px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 16px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -278,7 +278,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 id="mlab" class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -286,19 +286,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="theme-button" onclick="selectTheme('数与运算')">
+                <button class="theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="theme-button" onclick="selectTheme('量与计量')">
+                <button class="theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="theme-button" onclick="selectTheme('图形与几何')">
+                <button class="theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="theme-button" onclick="selectTheme('概率与统计')">
+                <button class="theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -343,7 +343,7 @@
             transitionScreens('welcomeScreen', 'themeSelectionScreen');
         }
 
-    function selectTheme(theme) {
+    function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';
@@ -366,6 +366,9 @@
             from.style.pointerEvents = 'none';
 
             // Adjust container size based on the target screen
+            // - welcomeScreen: 40% width, 250px height
+            // - themeSelectionScreen: 60% width, 350px height
+            // - experimentScreen: 90% width, 80vh height
             if (toScreen === 'welcomeScreen') {
                 container.style.width = '40%';
                 container.style.height = '250px';

--- a/MLab_0.3.9.html
+++ b/MLab_0.3.9.html
@@ -94,7 +94,7 @@
             margin-bottom: 20px;
             color: var(--text-color);
         }
-        .mathlab-by {
+        .mlab-by {
             font-size: 16px;
             margin-bottom: 20px;
             color: var(--text-color);
@@ -279,7 +279,7 @@
     <div class="container" role="main">
         <div id="welcomeScreen">
             <h1 id="mlab" class="welcome-text">MLab</h1>
-            <div class="mathlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
+            <div class="mlab-by" aria-label="Created by Etin Leo">By Etin Leo</div>
             <button id="startButton" class="button" onclick="startExploration()" aria-label="Start exploring MLab">
                 Start
             </button>
@@ -287,19 +287,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="theme-button" onclick="selectTheme('数与运算')">
+                <button class="theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="theme-button" onclick="selectTheme('量与计量')">
+                <button class="theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="theme-button" onclick="selectTheme('图形与几何')">
+                <button class="theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="theme-button" onclick="selectTheme('概率与统计')">
+                <button class="theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -344,7 +344,7 @@
             transitionScreens('welcomeScreen', 'themeSelectionScreen');
         }
 
-    function selectTheme(theme) {
+    function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             button.style.transform = 'scale(0.95)';
@@ -367,6 +367,9 @@
             from.style.pointerEvents = 'none';
 
             // Adjust container size based on the target screen
+            // - welcomeScreen: 40% width, 250px height
+            // - themeSelectionScreen: 60% width, 350px height
+            // - experimentScreen: 90% width, 80vh height
             if (toScreen === 'welcomeScreen') {
                 container.style.width = '40%';
                 container.style.height = '250px';

--- a/MLab_0.4.3.html
+++ b/MLab_0.4.3.html
@@ -309,19 +309,19 @@
         <div id="themeSelectionScreen">
             <h2 class="theme-selection-title">选择主题</h2>
             <div class="theme-buttons">
-                <button class="theme-button" onclick="selectTheme('数与运算')">
+                <button class="theme-button" onclick="selectTheme('数与运算', event)">
                     <i class="fas fa-calculator"></i>
                     数与运算
                 </button>
-                <button class="theme-button" onclick="selectTheme('量与计量')">
+                <button class="theme-button" onclick="selectTheme('量与计量', event)">
                     <i class="fas fa-balance-scale"></i>
                     量与计量
                 </button>
-                <button class="theme-button" onclick="selectTheme('图形与几何')">
+                <button class="theme-button" onclick="selectTheme('图形与几何', event)">
                     <i class="fas fa-shapes"></i>
                     图形与几何
                 </button>
-                <button class="theme-button" onclick="selectTheme('概率与统计')">
+                <button class="theme-button" onclick="selectTheme('概率与统计', event)">
                     <i class="fas fa-chart-bar"></i>
                     概率与统计
                 </button>
@@ -383,7 +383,7 @@
             transitionScreens('welcomeScreen', 'themeSelectionScreen');
         }
 
-        function selectTheme(theme) {
+        function selectTheme(theme, event) {
             console.log(`Selected theme: ${theme}`);
             const button = event.target.closest('.theme-button');
             if (!button) {
@@ -408,6 +408,11 @@
             from.style.opacity = '0';
             from.style.transform = 'translateY(-20px)';
             from.style.pointerEvents = 'none';
+
+            // Adjust container size based on the target screen
+            // - welcomeScreen: 40% width, 250px height
+            // - themeSelectionScreen: 60% width, 350px height
+            // - experimentScreen: 90% width, 80vh height
 
             if (toScreen === 'welcomeScreen') {
                 container.style.width = '40%';

--- a/mlab.js
+++ b/mlab.js
@@ -1,0 +1,48 @@
+function initializeExperiment() {}
+
+function transitionScreens(fromScreen, toScreen) {
+    const from = document.getElementById(fromScreen);
+    const to = document.getElementById(toScreen);
+    const container = document.querySelector('.container');
+
+    from.style.opacity = '0';
+    from.style.transform = 'translateY(-20px)';
+    from.style.pointerEvents = 'none';
+
+    if (toScreen === 'welcomeScreen') {
+        container.style.width = '40%';
+        container.style.height = '250px';
+    } else if (toScreen === 'themeSelectionScreen') {
+        container.style.width = '60%';
+        container.style.height = '350px';
+    } else if (toScreen === 'experimentScreen') {
+        container.style.width = '90%';
+        container.style.height = '80vh';
+    }
+
+    setTimeout(() => {
+        to.style.opacity = '1';
+        to.style.transform = 'translateY(0)';
+        to.style.pointerEvents = 'auto';
+        if (toScreen === 'experimentScreen') {
+            initializeExperiment();
+        }
+    }, 250);
+}
+
+function selectTheme(theme, event) {
+    const button = event.target.closest('.theme-button');
+    if (!button) {
+        return;
+    }
+    button.style.transform = 'scale(0.95)';
+    setTimeout(() => {
+        button.style.transform = '';
+    }, 100);
+
+    if (theme === '数与运算') {
+        transitionScreens('themeSelectionScreen', 'experimentScreen');
+    }
+}
+
+module.exports = { selectTheme, transitionScreens, initializeExperiment };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mlab",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/themeSelection.test.js
+++ b/tests/themeSelection.test.js
@@ -1,0 +1,24 @@
+const { JSDOM } = require('jsdom');
+const { selectTheme } = require('../mlab');
+
+test('selectTheme transitions to experiment screen', () => {
+  const dom = new JSDOM(`<!doctype html><div class="container">
+      <div id="themeSelectionScreen"></div>
+      <div id="experimentScreen" style="opacity:0"></div>
+      <button class="theme-button"></button>
+    </div>`);
+
+  global.document = dom.window.document;
+  global.initializeExperiment = jest.fn();
+
+  jest.useFakeTimers();
+
+  const button = dom.window.document.querySelector('.theme-button');
+  const event = { target: button };
+  selectTheme('数与运算', event);
+
+  jest.runAllTimers();
+
+  const experiment = dom.window.document.getElementById('experimentScreen');
+  expect(experiment.style.opacity).toBe('1');
+});


### PR DESCRIPTION
## Summary
- rename `.mathlab-by` CSS class to `.mlab-by`
- pass `event` explicitly to `selectTheme`
- clarify container sizing comments for each screen size
- add simple Jest+jsdom test for theme selection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845456bbb0c8322ab6089ae82127946